### PR TITLE
Wine details in Modal

### DIFF
--- a/client/src/components/Card/index.js
+++ b/client/src/components/Card/index.js
@@ -42,15 +42,14 @@ class WineCard extends React.Component {
                                 <div className="col-2">
                                     <button onClick={this.props.onAddToCart} className="btn btn-primary ">Add to Cart</button>
                                 </div>
-                                <div className="col-2">
-                                <Link to={this.props.winelink}>
-                                <button className="btn btn-primary">{this.props.btnName}</button>
-                                </Link>
-                                </div>
+                                {this.props.onViewDetails ? (
+                                    <div className="col-2">
+                                        <button onClick={this.props.onViewDetails} className="btn btn-primary">View Details</button>
+                                    </div>
+                                ) : ""}
                                 
                             </div>
 
-                            <a href="#" className="card-link">Customer Reviews</a>
                         </div>
                     </div>
                 </div>

--- a/client/src/components/TopNav/index.js
+++ b/client/src/components/TopNav/index.js
@@ -29,7 +29,7 @@ class TopNav extends Component {
               Blogs We Love
             </Nav.Link>
             <Nav.Link as={Link} to="/cart">
-              <i class="fas fa-shopping-cart"> {this.props.cartItems.length} </i>
+              <i className="fas fa-shopping-cart"> {this.props.cartItems.length} </i>
             </Nav.Link>
           </Nav>
         </Navbar.Collapse>

--- a/client/src/pages/WineDetailsModal.js
+++ b/client/src/pages/WineDetailsModal.js
@@ -1,0 +1,44 @@
+import React, { Component } from 'react';
+import Modal from "react-bootstrap/Modal";
+import WineCard from "../components/Card";
+import VineyardList from "../components/VineyardList";
+
+class WineDetailsModal extends Component {
+
+    render() { 
+        return (
+            <div>
+                {this.props.wine ? (
+                    <Modal show={this.props.showModal} size="lg" onHide={this.props.hideModal}>
+                        <Modal.Header closeButton>
+                            <Modal.Title>{this.props.wine.name}</Modal.Title>
+                        </Modal.Header>
+                        <Modal.Body>
+                            <WineCard
+                                picture = {this.props.wine.pictures[0].base_url + this.props.wine.pictures[0].public_id}
+                                name = {this.props.wine.name}
+                                varietal = {this.props.wine.varietal}
+                                shortDescription = {this.props.wine.longDescription || this.props.wine.shortDescription}
+                                volume = {this.props.wine.volume}
+                                price = {this.props.wine.price}
+                                onAddToCart = {() => this.props.onAddToCart(this.props.wine)}
+                            /> 
+
+                            {/* Vineyard information */}
+                            <VineyardList
+                                vineyardName = {this.props.wine.vineyard.fullName}
+                                subregion = {this.props.wine.nested_region}
+                                vineyardRegion = {this.props.wine.vineyard.region}  
+                                vineyardDetails ={this.props.wine.vineyard.longDescription}
+                            />
+
+
+                        </Modal.Body>
+                    </Modal>
+                ) : ""}
+            </div>
+        );
+    }
+}
+ 
+export default WineDetailsModal;

--- a/client/src/pages/Wines.js
+++ b/client/src/pages/Wines.js
@@ -1,7 +1,7 @@
 import React from "react";
 import API from "../utils/API";
 import WineCard from "../components/Card";
-import { Link } from "react-router-dom";
+import WineDetailsModal from "./WineDetailsModal";
 import "./style.css"
 
 class Wines extends React.Component {
@@ -15,7 +15,10 @@ class Wines extends React.Component {
         region: "",     // User's region choice
         varietal: "",   // User's varietal choice
         price: "",      // User's price choice (high/medium/low)
-        textQuery: ""   // User's search terms
+        textQuery: "",  // User's search terms
+
+        showModal: false,
+        selectedWine: null
     };
 
     componentDidMount() {
@@ -87,12 +90,26 @@ class Wines extends React.Component {
             textQuery: ""
         }, () => this.loadWines());
     }
+
+    onViewDetails = (wine) => {
+        this.setState({ 
+            showModal: true,
+            selectedWine: wine
+        });
+    }
+
+    handleHideModal = () => {
+        this.setState({
+            showModal: false,
+            selectedWine: null
+        });
+    }
     
     render() {
         return (
             <div>
 
-                <form onSubmit={this.handleFormSubmit}>
+                <form onSubmit={this.handleFormSubmit} className="wineFilterForm">
 
                     {/* Color selector */}
                     <select value={this.state.color} onChange={this.handleColorChange}>
@@ -149,12 +166,17 @@ class Wines extends React.Component {
                             volume = {wine.volume}
                             price = {wine.price}
                             onAddToCart = {() => this.props.onAddToCart(wine)}
-                            winelink = {"/wine/" + wine._id}
-                            btnName = "View Details"
+                            onViewDetails = {() => this.onViewDetails(wine)}
                         >                                
                         </WineCard>
                     ))
-                : <div>No wines available</div>} 
+                : <div>No wines available</div>}
+                <WineDetailsModal 
+                    showModal={this.state.showModal} 
+                    hideModal={this.handleHideModal} 
+                    wine={this.state.selectedWine} 
+                    onAddToCart = {() => this.props.onAddToCart(this.state.selectedWine)}
+                />
             </div>
 
             </div>

--- a/client/src/pages/style.css
+++ b/client/src/pages/style.css
@@ -30,6 +30,11 @@ select {
   margin-left: 7px;
 }
 
+.wineFilterForm ::placeholder {
+  color: rgb(83, 6, 6);
+  font-family: "Times New Roman", Times, serif;
+}
+
 .scroll {
   height: 420px;
   overflow-y: scroll;


### PR DESCRIPTION
When clicking on the back to browse button, we the entire page was getting reset. As a result, we were losing the previous search results. Creating a modal to display wine details is an easy way to avoid this problem. When the modal is closed, the search results are still behind it. 

![Screen Shot 2019-09-28 at 8 24 04 AM](https://user-images.githubusercontent.com/46358080/65817146-66bf4d00-e1c9-11e9-8474-0cb8ccf74b0b.png)
![Screen Shot 2019-09-28 at 8 23 54 AM](https://user-images.githubusercontent.com/46358080/65817147-66bf4d00-e1c9-11e9-8b43-d600e2566b3c.png)

